### PR TITLE
Fix counter IDs and merges

### DIFF
--- a/src/CounterIndex.js
+++ b/src/CounterIndex.js
@@ -13,10 +13,17 @@ class CounterIndex {
 
   updateIndex (oplog) {
     if (this._index) {
-      const createCounter = e => Counter.from(e.payload.value)
-      const mergeToIndex = e => this._index.merge(e)
+      const mergeWith = (counter, otherCounters) => {
+        // Go through each counter in the other counter
+        Object.entries(otherCounters).forEach(([id, value]) => {
+          // Take the maximum of the counter value we have or the counter value they have
+          counter._counters[id] = Math.max(counter._counters[id] || 0, value)
+        })
+      }
+      const getCounter = e => e.payload.value.counters
+      const mergeToIndex = e => mergeWith(this._index, e)
       oplog.values.filter(e => e && e.payload.op === 'COUNTER')
-        .map(createCounter)
+        .map(getCounter)
         .forEach(mergeToIndex)
     }
   }

--- a/src/CounterIndex.js
+++ b/src/CounterIndex.js
@@ -13,15 +13,8 @@ class CounterIndex {
 
   updateIndex (oplog) {
     if (this._index) {
-      const mergeWith = (counter, otherCounters) => {
-        // Go through each counter in the other counter
-        Object.entries(otherCounters).forEach(([id, value]) => {
-          // Take the maximum of the counter value we have or the counter value they have
-          counter._counters[id] = Math.max(counter._counters[id] || 0, value)
-        })
-      }
       const getCounter = e => e.payload.value.counters
-      const mergeToIndex = e => mergeWith(this._index, e)
+      const mergeToIndex = _counters => this._index.merge({ _counters })
       oplog.values.filter(e => e && e.payload.op === 'COUNTER')
         .map(getCounter)
         .forEach(mergeToIndex)

--- a/src/CounterStore.js
+++ b/src/CounterStore.js
@@ -10,7 +10,7 @@ class CounterStore extends Store {
       Object.assign(options, { Index: CounterIndex })
     }
     super(ipfs, id, dbname, options)
-    this._index = new this.options.Index(this.identity.id)
+    this._index = new this.options.Index(this.identity.publicKey)
     this._type = 'counter'
   }
 
@@ -19,7 +19,7 @@ class CounterStore extends Store {
   }
 
   inc (amount, options = {}) {
-    const counter = new Counter(this.identity.id, Object.assign({}, this._index.get()._counters))
+    const counter = new Counter(this.identity.publicKey, Object.assign({}, this._index.get()._counters))
     counter.increment(amount)
     return this._addOperation({
       op: 'COUNTER',

--- a/src/CounterStore.js
+++ b/src/CounterStore.js
@@ -10,6 +10,7 @@ class CounterStore extends Store {
       Object.assign(options, { Index: CounterIndex })
     }
     super(ipfs, id, dbname, options)
+    this._index = new this.options.Index(this.identity.id)
     this._type = 'counter'
   }
 
@@ -18,7 +19,7 @@ class CounterStore extends Store {
   }
 
   inc (amount, options = {}) {
-    const counter = new Counter(this.identity.publicKey, Object.assign({}, this._index.get()._counters))
+    const counter = new Counter(this.identity.id, Object.assign({}, this._index.get()._counters))
     counter.increment(amount)
     return this._addOperation({
       op: 'COUNTER',


### PR DESCRIPTION
This PR will change the counter store and index to use `identity.id` as the counter ID and thus fixes merging counters.

Before this PR, the counter ID (ie. database ID) and the user ID (ie. writer ID) got mixed up resulting in mangled state where, while having correct data from updates/writes, contained also a counter for the database ID. This isn't supposed to be the case and counters should only contains pairs of `(writerID, value)`.

~~This PR also changes the CounterStore to use `identity.id` instead of `identity.publicKey` as the writer's ID. This makes the ID length shorter, from `047bf7a74b85cc51a2080dac60dc6e1734343c73bc5c1c03ee68a2104f97e3fd8981833892f96110a281cd0ebf50e7cd32ffe93142b3dd238aaaba3c2903010a55` to `025a8e1ac19907f097cae707e7527cea9f46fc62af171def339a3174f663cb6ddc` which will save bytes in the underlying data format (and replication/transfer bytes).~~

~~Not sure if this is backwards compatible (because of the key change). If not, we can drop the change of publicKey->id from the PR.~~